### PR TITLE
Use the old, pre-functional components version of MediaImage

### DIFF
--- a/src/components/MediaImage.vue
+++ b/src/components/MediaImage.vue
@@ -1,24 +1,17 @@
 <template>
   <div
     class="lux-media-image"
-    :class="[
-      props.height,
-      { 'lux-default-thumbnail': !props.src },
-      data.class,
-      data.staticClass,
-    ]"
-    :style="[data.style, data.staticStyle]"
-    v-bind="data.attrs"
-    v-on="listeners"
+    :class="[height, { 'lux-default-thumbnail': !source }]"
   >
     <img
-      v-if="props.src"
-      @error="$options.methods.fixSrc"
-      :src="props.src"
-      :alt="props.alt"
-      :class="[{ 'lux-cover': props.cover }, { 'lux-contain': props.contain }]"
+      v-if="source"
+      @error="source = null"
+      :src="source"
+      :alt="alt"
+      :class="[{ 'lux-cover': cover }, { 'lux-contain': contain }]"
     />
     <lux-icon-base
+      v-else
       width="50"
       height="50"
       icon-name="file"
@@ -38,12 +31,10 @@ export default {
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  methods: {
-    fixSrc(event) {
-      console.log(event);
-      event.target.parentNode.classList.add("lux-default-thumbnail");
-      event.target.remove();
-    },
+  data: function () {
+    return {
+      source: this.src,
+    };
   },
   props: {
     /**


### PR DESCRIPTION
This resolves the problem "TypeError: _ctx.props is undefined" that displays in the style guide instead of the MediaImage component.