### PR TITLE
Export components as a vue plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import * as components from "./components"
 
-const Lux = {
-  install(app) {
+export default {
+  // Vue plugins must expose an install() method, see
+  // https://vuejs.org/guide/reusability/plugins.html
+  install(app, options) {
     for (const componentKey in components) {
-      app.use(components[componentKey])
+      app.component(components[componentKey].name, components[componentKey])
     }
   },
 }
-
-export default Lux

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,17 +21,5 @@ export default defineConfig({
       // the proper extensions will be added
       fileName: "lux-styleguidist",
     },
-    rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ["vue"],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          vue: "Vue",
-        },
-      },
-    },
   },
 })


### PR DESCRIPTION
According to the Vue documentation, we need to implement an install() method if other applications wish to use this as a plugin.  See
https://vuejs.org/guide/reusability/plugins.html

Also, the vite config that externalizes the vue dependency doesn't appear to be needed, and it threw an error in approvals.

Helps with #41 