### PR TITLE
Don't package all of Vue inside the bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "core-js": "^3.8.3",
         "register-service-worker": "^1.7.2",
-        "vue": "^3.2.13",
-        "vuedraggable": "^4.1.0",
+        "vue-draggable-plus": "^0.3.5",
         "vuex": "^4.0.0"
       },
       "devDependencies": {
@@ -39,6 +38,7 @@
         "push-dir": "^0.4.1",
         "sass": "^1.69.3",
         "sass-loader": "^13.3.2",
+        "vue": "^3.2.13",
         "vue-cli-plugin-styleguidist": "~4.72.4"
       }
     },
@@ -4037,6 +4037,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-PvgWCx1Lbgm88FdQ6S7OGvLIjWS66mudKPlfdrWil0TjsO5zmoZmzoKiiwRShs1dwPgrlkr0N4ewuy0/+QUXYQ==",
+      "peer": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.6",
@@ -20673,11 +20679,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/sortablejs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
-      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
-    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -22862,6 +22863,19 @@
       "dev": true,
       "engines": {
         "node": ">=16.14"
+      }
+    },
+    "node_modules/vue-draggable-plus": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/vue-draggable-plus/-/vue-draggable-plus-0.3.5.tgz",
+      "integrity": "sha512-HqIxV4Wr4U5LRPLRi2oV+EJ4g6ibyRKhuaiH4ZQo+LxK4zrk2XcBk9UyXC88OXp4SAq0XYH4Wco/T3LX5kJ79A==",
+      "peerDependencies": {
+        "@types/sortablejs": "^1.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -25355,17 +25369,6 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
-    },
-    "node_modules/vuedraggable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
-      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
-      "dependencies": {
-        "sortablejs": "1.14.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.1"
-      }
     },
     "node_modules/vuex": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "core-js": "^3.8.3",
     "register-service-worker": "^1.7.2",
-    "vue": "^3.2.13",
-    "vuedraggable": "^4.1.0",
+    "vue-draggable-plus": "^0.3.5",
     "vuex": "^4.0.0"
   },
   "devDependencies": {
@@ -58,6 +57,7 @@
     "prettier": "^2.4.1",
     "sass": "^1.69.3",
     "sass-loader": "^13.3.2",
+    "vue": "^3.2.13",
     "vue-cli-plugin-styleguidist": "~4.72.4"
   },
   "gitHooks": {

--- a/src/components/LuxGallery.vue
+++ b/src/components/LuxGallery.vue
@@ -1,9 +1,8 @@
 <template>
-  <draggable class="lux-gallery" v-model="items" item-key="id" tag="div" @click="deselect($event)">
-    <template #item="{ element }">
+  <VueDraggable class="lux-gallery" v-model="items" tag="div" @click="deselect($event)" ref="el">
+    <template v-for="element in items" :key="element.id">
       <lux-card
         :id="element.id"
-        :key="element.id"
         class="lux-galleryCard"
         :cardPixelWidth="cardPixelWidth"
         size="medium"
@@ -17,13 +16,12 @@
         <lux-text-style variation="default">{{ element.caption }}</lux-text-style>
       </lux-card>
     </template>
-  </draggable>
+  </VueDraggable>
 </template>
 
 <script>
 import store from "../store"
-// import { mapState, mapGetters } from "vuex"
-import draggable from "vuedraggable"
+import { VueDraggable } from "vue-draggable-plus"
 /*
  * Gallery is a grid of images with captions.
  */
@@ -33,7 +31,7 @@ export default {
   release: "1.0.0",
   type: "Pattern",
   components: {
-    draggable,
+    VueDraggable,
   },
   // computed: mapState([
   //   // map this.count to store.state.count

--- a/tests/unit/specs/components/__snapshots__/luxGallery.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxGallery.spec.js.snap
@@ -4,10 +4,10 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
 <div
   class="lux-gallery"
 >
+  
   <lux-card
     cardpixelwidth="300"
     class="lux-galleryCard"
-    data-draggable="true"
     disabled="false"
     edited="false"
     id="1"
@@ -31,7 +31,6 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
   <lux-card
     cardpixelwidth="300"
     class="lux-galleryCard"
-    data-draggable="true"
     disabled="false"
     edited="false"
     id="2"
@@ -55,7 +54,6 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
   <lux-card
     cardpixelwidth="300"
     class="lux-galleryCard"
-    data-draggable="true"
     disabled="false"
     edited="false"
     id="3"
@@ -76,5 +74,6 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
       three
     </lux-text-style>
   </lux-card>
+  
 </div>
 `;

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,5 +21,17 @@ export default defineConfig({
       // the proper extensions will be added
       fileName: "lux-styleguidist",
     },
+    rollupOptions: {
+      // make sure to externalize deps that shouldn't be bundled
+      // into your library
+      external: ["vue"],
+      output: {
+        // Provide global variables to use in the UMD build
+        // for externalized deps
+        globals: {
+          vue: "Vue",
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
* Brings the size of dist/lux-styleguidist.mjs from 436.20 kB to 111.31 kB
* Uses vue as a devDependency, rather than a dependency
* Partially reverts PR #43 to externalize Vue in the vite config
* Use VueDraggablePlus, which does not rely on a Vue 2 default import, rather than VueDraggable, which does.

part of https://github.com/pulibrary/approvals/issues/995