### PR TITLE
Use np for the whole release task

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ npm install --global np # don't add this as a devDependency, otherwise you won't
 npm run release
 ```
 
+#### Tips
+* If you have a passphrase on your ssh key, run ssh-add ~/.ssh/id_ed25519 (or wherever your key is located).
+* If you use a security key, rather than an authenticator app, for two-factor authentication in npmjs.com, make sure that "Require two-factor authentication for write actions" is not checked in your account 2FA settings. If it is checked, np will ask you for an OTP from your phone, and won't allow you to push without it.
+
 ### Deploy the styleguide to GitHub Pages
 ```
 npm run deploy

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "lint": "vue-cli-service lint",
     "deploy": "npm run build; npm run styleguide:build; push-dir --dir=styleguide --branch=gh-pages --cleanup",
-    "release": "np --no-publish && npm publish && npm run deploy",
+    "release": "npm run build && np && npm run deploy",
     "styleguide": "vue-cli-service styleguidist",
     "styleguide:build": "vue-cli-service styleguidist:build"
   },


### PR DESCRIPTION
We were previously having trouble with `np` where npm would ask for an OTP whenever we created a release.  However, it turns out that this is something we can adjust in our npm.js settings, so this PR includes the instructions for changing those settings, and returns to using `np`.

closes #29 