### PR TITLE
Reduce the amount of warning from running the test suite

### DIFF
--- a/tests/unit/specs/components/__snapshots__/luxGallery.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxGallery.spec.js.snap
@@ -5,7 +5,7 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
   class="lux-gallery"
 >
   
-  <lux-card
+  <lux-card-stub
     cardpixelwidth="300"
     class="lux-galleryCard"
     disabled="false"
@@ -13,22 +13,8 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
     id="1"
     selected="false"
     size="medium"
-  >
-    <lux-media-image
-      src="https://picsum.photos/600/300/?random"
-    />
-    <lux-heading
-      level="h2"
-    >
-      First
-    </lux-heading>
-    <lux-text-style
-      variation="default"
-    >
-      one
-    </lux-text-style>
-  </lux-card>
-  <lux-card
+  />
+  <lux-card-stub
     cardpixelwidth="300"
     class="lux-galleryCard"
     disabled="false"
@@ -36,22 +22,8 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
     id="2"
     selected="false"
     size="medium"
-  >
-    <lux-media-image
-      src="https://picsum.photos/600/300/?random"
-    />
-    <lux-heading
-      level="h2"
-    >
-      Second
-    </lux-heading>
-    <lux-text-style
-      variation="default"
-    >
-      two
-    </lux-text-style>
-  </lux-card>
-  <lux-card
+  />
+  <lux-card-stub
     cardpixelwidth="300"
     class="lux-galleryCard"
     disabled="false"
@@ -59,21 +31,7 @@ exports[`LuxGallery.vue has the expected html structure 1`] = `
     id="3"
     selected="false"
     size="medium"
-  >
-    <lux-media-image
-      src="https://foo/bar"
-    />
-    <lux-heading
-      level="h2"
-    >
-      Third
-    </lux-heading>
-    <lux-text-style
-      variation="default"
-    >
-      three
-    </lux-text-style>
-  </lux-card>
+  />
   
 </div>
 `;

--- a/tests/unit/specs/components/__snapshots__/luxMediaImage.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxMediaImage.spec.js.snap
@@ -4,14 +4,12 @@ exports[`LuxMediaImage.vue has the expected html structure 1`] = `
 <div
   class="lux-media-image medium lux-default-thumbnail"
 >
-  <lux-icon-base
+  <lux-icon-base-stub
     height="50"
     icon-color="rgb(225,225,225)"
     icon-hide="true"
     icon-name="file"
     width="50"
-  >
-    <lux-icon-file />
-  </lux-icon-base>
+  />
 </div>
 `;

--- a/tests/unit/specs/components/luxDatePicker.spec.js
+++ b/tests/unit/specs/components/luxDatePicker.spec.js
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils"
 import LuxDatePicker from "@/components/LuxDatePicker.vue"
 import ResizeObserver from "resize-observer-polyfill"
 import { nextTick } from "vue"
-import { log } from "console"
 
 global.ResizeObserver = ResizeObserver
 

--- a/tests/unit/specs/components/luxGallery.spec.js
+++ b/tests/unit/specs/components/luxGallery.spec.js
@@ -44,7 +44,14 @@ describe("LuxGallery.vue", () => {
       propsData: {
         galleryItems: items,
       },
-      stubs: ["lux-card", "lux-heading", "lux-text-style", "lux-media-image"],
+      global: {
+        stubs: {
+          "lux-card": true,
+          "lux-heading": true,
+          "lux-text-style": true,
+          "lux-media-image": true,
+        },
+      },
     })
   })
 

--- a/tests/unit/specs/components/luxMediaImage.spec.js
+++ b/tests/unit/specs/components/luxMediaImage.spec.js
@@ -14,7 +14,12 @@ describe("LuxMediaImage.vue", () => {
         cover: true,
         contain: false,
       },
-      stubs: ["lux-icon-base", "lux-icon-file"],
+      global: {
+        stubs: {
+          "lux-icon-base": true,
+          "lux-icon-file": true,
+        },
+      },
     })
   })
 

--- a/tests/unit/specs/components/luxWrapper.spec.js
+++ b/tests/unit/specs/components/luxWrapper.spec.js
@@ -8,7 +8,7 @@ describe("LuxWrapper.vue", () => {
   it("can accept an arbitrary number of pixels in the maxWidth prop", () => {
     wrapper = mount(LuxWrapper, {
       props: {
-        maxWidth: "123",
+        maxWidth: 123,
       },
     })
     expect(wrapper.find("div").attributes("style")).toEqual("max-width: 123px;")


### PR DESCRIPTION
Brings us from 6112 lines of warnings to 1248 lines by

- Using the [new vue-test-utils syntax](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount) for stubbing child components
- Correcting some mock data that was in the incorrect type