### PR TITLE
LuxInputSelect: Use focusSelect() method with ref instead of a focus prop and attribute

### DIFF
--- a/src/components/LuxInputSelect.vue
+++ b/src/components/LuxInputSelect.vue
@@ -12,10 +12,10 @@
       ]"
       :disabled="disabled"
       :required="required"
-      :focus="focus"
       :multiple="multiple"
       :errormessage="errormessage"
       :value="value"
+      ref="select"
       :name="name"
       @change="change($event)"
       @blur="inputblur($event.target)"
@@ -164,14 +164,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    /**
-     * Manually trigger input field’s focus state.
-     * `true, false`
-     */
-    focus: {
-      type: Boolean,
-      default: false,
-    },
   },
   methods: {
     change(event) {
@@ -179,6 +171,12 @@ export default {
     },
     inputblur(value) {
       this.$emit("inputblur", value)
+    },
+    focusSelect() {
+      this.$nextTick(() => {
+        const selectRef = this.$refs.select
+        selectRef.focus()
+      })
     },
   },
 }

--- a/tests/unit/specs/components/luxInputSelect.spec.js
+++ b/tests/unit/specs/components/luxInputSelect.spec.js
@@ -24,6 +24,7 @@ describe("LuxInputSelect.vue", () => {
           },
         ],
       },
+      attachTo: document.body,
     })
   })
 
@@ -66,5 +67,17 @@ describe("LuxInputSelect.vue", () => {
 
   it("has the expected html structure", () => {
     expect(wrapper.element).toMatchSnapshot()
+  })
+
+  describe("focusSelect()", () => {
+    it("focuses the select", async () => {
+      const select = wrapper.find("select").element
+      expect(select).not.toBe(document.activeElement)
+
+      wrapper.vm.focusSelect()
+      await nextTick()
+
+      expect(select).toBe(document.activeElement)
+    })
   })
 })


### PR DESCRIPTION
The previous version failed to set focus in Vue 3.