### PR TITLE
Remove duplicate mounted()

### DIFF
--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -205,15 +205,6 @@ export default {
       }
     },
   },
-  mounted() {
-    let vm = this
-
-    vm.$nextTick(function () {
-      if (vm.focused) {
-        this.$refs.autoComplete.focus()
-      }
-    })
-  },
   watch: {
     // Once the items content changes, it means the parent component
     // provided the needed data

--- a/tests/unit/specs/components/luxAutocompleteInput.spec.js
+++ b/tests/unit/specs/components/luxAutocompleteInput.spec.js
@@ -19,14 +19,14 @@ describe("InputAutocomplete.vue", () => {
         ],
         focused: true,
       },
+      attachTo: document.body,
     })
   })
 
-  //TODO: https://github.com/pulibrary/lux-styleguidist/issues/91
-  // it("should be focused when the focused property is set to true", () => {
-  //   const input = wrapper.find("#displayInput").element
-  //   expect(input).toBe(document.activeElement)
-  // })
+  it("should be focused when the focused property is set to true", () => {
+    const input = wrapper.find("#displayInput").element
+    expect(input).toBe(document.activeElement)
+  })
 
   it("should populate the inputValue with an id when defaultValue is passed and found in items", () => {
     expect(wrapper.vm.inputValue).toBe(2)


### PR DESCRIPTION
closes #91 

Remove duplicate mounted()
Include attachTo: document.body in the beforeEach() wrapper