### PR TITLE
DatePicker: date range needs to use the inputValue.start or inputValue.end subproperty

### DIFF
--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -43,7 +43,7 @@
           :required="required"
           :value="!range ? '' : formatStart() + ' - ' + formatEnd()"
           @inputvaluechange="updateRangeInput($event)"
-          v-on="inputEvents"
+          v-on="inputEvents.start"
           :placeholder="placeholder"
           :helper="helper"
         ></lux-input-text>


### PR DESCRIPTION
This is according to the documentation at https://vcalendar.io/datepicker/slot-content.html#range-inputs

Helps with #107 