### PR TITLE
Declare the emits used in inputSelect

### DIFF
--- a/src/components/LuxInputSelect.vue
+++ b/src/components/LuxInputSelect.vue
@@ -50,6 +50,7 @@ export default {
       return this.errormessage.length
     },
   },
+  emits: ["change", "inputblur"],
   props: {
     /**
      * Sets the value of the selected option.

--- a/tests/unit/specs/components/luxInputSelect.spec.js
+++ b/tests/unit/specs/components/luxInputSelect.spec.js
@@ -32,7 +32,7 @@ describe("LuxInputSelect.vue", () => {
     const select = wrapper.find("select")
     select.trigger("change")
     const emitted = wrapper.emitted()
-    expect(Object.prototype.hasOwnProperty.call(emitted, "change")).toBe(true)
+    expect(emitted.change.length).toBe(1)
     expect(emitted.change[0]).toEqual(["two"])
   })
 


### PR DESCRIPTION
The Vue 3 migration documentation notes that if you don't declare it, you can get two events when you only expect one: https://v3-migration.vuejs.org/breaking-changes/emits-option.html#migration-strategy

Helps with https://github.com/pulibrary/approvals/issues/1049