### PR TITLE
LuxHyperlink should not have pointer-events turned off via CSS

### DIFF
--- a/src/components/LuxHyperlink.vue
+++ b/src/components/LuxHyperlink.vue
@@ -53,6 +53,7 @@ export default {
 @import "../assets/styles/spacing.scss";
 
 .lux-link {
+  pointer-events: auto;
   color: --var(color-bleu-de-france-dark);
   font-family: --var(font-family-text);
   text-decoration: none;


### PR DESCRIPTION
If it is in a LuxHeading, it inherits pointer-events:none, making it unclickable

Helps with https://github.com/pulibrary/approvals/issues/1055