### PR TITLE
Slotted css in textarea

### DIFF
--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -329,7 +329,7 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
       width: 100%;
     }
 
-    input,
+    :slotted(input),
     textarea {
       @include reset;
       @include inset-squish-space(16px);


### PR DESCRIPTION
closes https://github.com/pulibrary/approvals/issues/1085

adds back the border in the textarea of the inputbox