### PR TITLE
Remove lux input text focused example

### DIFF
--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -443,7 +443,6 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
     <lux-input-text id="foo" name="value" label="Input" :hide-label="true" placeholder="Write your text" helper="This is helper text to help the user fill out this field" size="small"></lux-input-text>
 
     <lux-input-text id="bar" name="value" label=":hover" hover placeholder="Write your text"></lux-input-text>
-    <lux-input-text id="fee" name="value" label=":focused" focused placeholder="Write your text"></lux-input-text>
     <lux-input-text id="foe" name="value" label="[disabled]" disabled placeholder="Disabled input"></lux-input-text>
     <lux-input-text id="foe" name="value" label="Textarea" type="textarea"></lux-input-text>
 


### PR DESCRIPTION
It always causes the styleguide to jump down to the LuxInputText documentation, even if you are trying to consult the documentation for a different component