### PR TITLE
Clicking outside the dropdown menu should close it

### DIFF
--- a/src/components/LuxDropdownMenu.vue
+++ b/src/components/LuxDropdownMenu.vue
@@ -104,7 +104,7 @@ export default {
   },
   directives: {
     "click-outside": {
-      bind: function (el, binding, vNode) {
+      beforeMount: function (el, binding) {
         // Define Handler and cache it on the element
         const bubble = binding.modifiers.bubble
         const handler = e => {
@@ -118,7 +118,7 @@ export default {
         document.addEventListener("click", handler)
       },
 
-      unbind: function (el, binding) {
+      unmounted: function (el, binding) {
         // Remove Event Listeners
         document.removeEventListener("click", el.__vueClickOutside__)
         el.__vueClickOutside__ = null


### PR DESCRIPTION
[Vue 3 changed the names of the custom hooks](https://v3-migration.vuejs.org/breaking-changes/custom-directives#_3-x-syntax), this updates the names to the Vue 3 versions.

Part of https://github.com/pulibrary/approvals/issues/1065