### PR TITLE
Fixes the styleguide:build unterminated template literal syntax error

### DIFF
--- a/src/components/logos/LuxLogoLibrary.vue
+++ b/src/components/logos/LuxLogoLibrary.vue
@@ -34,7 +34,9 @@
 
 <script>
 /**
- * Official Princeton University Library Logo.
+ * Official Princeton University Library Brandmark and Wordmark combination Logo.
+ * Please, note that the white type on the first example below is not visible due
+ * to the white background color of the preview box.
  */
 export default {
   name: "LuxLogoLibrary",
@@ -77,10 +79,10 @@ export default {
 </style>
 
 <docs>
-    ```jsx
-    <div>
-      <lux-logo-library></lux-logo-library>
-      <lux-logo-library color="#000"></lux-logo-library>
-    </div>
-    ```
-  </docs>
+  ```jsx
+  <div>
+    <lux-logo-library></lux-logo-library>
+    <lux-logo-library color="#000"></lux-logo-library>
+  </div>
+  ```
+</docs>

--- a/src/components/logos/LuxLogoLibraryIcon.vue
+++ b/src/components/logos/LuxLogoLibraryIcon.vue
@@ -28,7 +28,7 @@
 
 <script>
 /**
- * Official Princeton University Library Logo.
+ * Official Princeton University Library Brandmark Logo.
  */
 export default {
   name: "LuxLogoLibraryIcon",
@@ -61,9 +61,9 @@ export default {
 </style>
 
 <docs>
-    ```jsx
-    <div>
-      <lux-logo-library-icon></lux-logo-library-icon>
-    </div>
-    ```
-  </docs>
+  ```jsx
+  <div>
+    <lux-logo-library-icon></lux-logo-library-icon>
+  </div>
+  ```
+</docs>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -16,6 +16,10 @@ module.exports = {
       components: "src/components/icons/[A-Z]*.vue",
     },
     {
+      name: "Logos",
+      components: "src/components/logos/[A-Z]*.vue",
+    },
+    {
       name: "Internal Components",
       components: "src/components/_*.vue",
     },


### PR DESCRIPTION
This fix also makes sure the logos show up in the docs and render in the LuxLibraryHeader component. 